### PR TITLE
Fix top 2 blocker security issues

### DIFF
--- a/src/main/java/demo/security/servlet/ScriptServlet.java
+++ b/src/main/java/demo/security/servlet/ScriptServlet.java
@@ -2,7 +2,6 @@ package demo.security.servlet;
 
 import demo.security.util.Utils;
 
-import javax.script.ScriptException;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -15,10 +14,6 @@ public class ScriptServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String data = request.getParameter("data");
-        try {
-            Utils.executeJs(data);
-        } catch (ScriptException e) {
-            throw new RuntimeException(e);
-        }
+        Utils.validateScriptInput(data);
     }
 }

--- a/src/main/java/demo/security/servlet/UserServlet.java
+++ b/src/main/java/demo/security/servlet/UserServlet.java
@@ -1,5 +1,6 @@
 package demo.security.servlet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import demo.security.util.DBUtils;
 import demo.security.util.SessionHeader;
 import org.apache.commons.codec.binary.Base64;
@@ -7,9 +8,7 @@ import org.apache.commons.codec.binary.Base64;
 import javax.servlet.*;
 import javax.servlet.http.*;
 import javax.servlet.annotation.*;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -38,8 +37,8 @@ public class UserServlet extends HttpServlet {
         if (sessionAuth != null) {
             try {
                 byte[] decoded = Base64.decodeBase64(sessionAuth);
-                ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(decoded));
-                return (SessionHeader) in.readObject();
+                ObjectMapper mapper = new ObjectMapper();
+                return mapper.readValue(decoded, SessionHeader.class);
             } catch (Exception e) {
                 return null;
             }

--- a/src/main/java/demo/security/util/SessionHeader.java
+++ b/src/main/java/demo/security/util/SessionHeader.java
@@ -3,6 +3,10 @@ import java.io.Serializable;
 public class SessionHeader implements Serializable {
     private String username;
     private String sessionId;
+
+    public SessionHeader() {
+    }
+
     public SessionHeader(String username, String sessionId) {
         this.username = username;
         this.sessionId = sessionId;

--- a/src/main/java/demo/security/util/Utils.java
+++ b/src/main/java/demo/security/util/Utils.java
@@ -6,9 +6,6 @@ import org.apache.commons.io.FileUtils;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -34,10 +31,10 @@ public class Utils {
         FileUtils.forceDelete(file);
     }
 
-    public static void executeJs(String input) throws ScriptException {
-        ScriptEngineManager manager = new ScriptEngineManager();
-        ScriptEngine engine = manager.getEngineByName("JavaScript");
-        engine.eval(input);
+    public static void validateScriptInput(String input) {
+        if (input == null || input.isBlank()) {
+            throw new IllegalArgumentException("Script input must not be empty");
+        }
     }
 
     public static void encrypt(byte[] key, byte[] ptxt) throws Exception {


### PR DESCRIPTION
## Summary

Fixes the two highest-priority open **blocker** security issues:

1. **S5135** (`UserServlet.java`) — Insecure deserialization of user-controlled `Session-Auth` header data. Replaced `ObjectInputStream` with Jackson JSON parsing.
2. **S5334** (`Utils.java`) — Dynamic execution of user-controlled JavaScript via `ScriptEngine.eval`. Replaced with input validation only; `ScriptServlet` updated accordingly.

## Test plan

- [x] `mvn compile test` passes locally
- [ ] SonarQube PR analysis quality gate passes
- [ ] Blocker issues S5135 and S5334 are resolved